### PR TITLE
Error handling for no Hue Bridges on network

### DIFF
--- a/src/hue.js
+++ b/src/hue.js
@@ -232,7 +232,7 @@ class Hue {
           errorCallback([{ error: {
             type: 404,
             address: url,
-            description: `No Hue Bridge found on local network`
+            description: 'No Hue Bridge found on local network'
           }}])
         }
         return

--- a/src/hue.js
+++ b/src/hue.js
@@ -227,6 +227,17 @@ class Hue {
       if (this.detectErrors(data, errorCallback))
         return
 
+      if (data.length === 0) {
+        if (typeof errorCallback === 'function') {
+          errorCallback([{ error: {
+            type: 404,
+            address: url,
+            description: `No Hue Bridge found on local network`
+          }}])
+        }
+        return
+      }
+
       this.ip = data[0].internalipaddress
 
       if (typeof callback === 'function')


### PR DESCRIPTION
Now the Hue.findIp method will call the error callback with an error message "No Hue Bridge found on local network" if the list of bridges found by the UPnP server is empty.