### PR TITLE
Typed commands no longer need 'lights' keyword

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,7 +99,7 @@ typingInput.onchange = e => {
   historyIndex = 0
 
   for (let command of hueCommands)
-    command.matchAndRun(typingInput.value, setLightState)
+    command.matchAndRun('lights ' + typingInput.value, setLightState)
 
   typingInput.value = ''
 }


### PR DESCRIPTION
The command keyword 'lights' is now prepended to typed commands so that you can just type commands like 'on' or '70%' and they will do the obvious thing instead of being ignored.
Requiring the 'lights' keyword at the start of the command only really makes sense for spoken commands where it might otherwise pick up unrelated speech.